### PR TITLE
Feature/todo filter

### DIFF
--- a/src/Components/TodoFilter/FilterButton.tsx
+++ b/src/Components/TodoFilter/FilterButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import Button from 'Components/Button';
+
+interface filterButtonProps {
+  toggleClick: boolean;
+  onClick?: () => void;
+}
+
+const FilterButton: React.FC<filterButtonProps> = ({
+  toggleClick,
+  children,
+  ...restProps
+}) => {
+  return (
+    <StyledFilterButton toggleClick={toggleClick} {...restProps}>
+      {children}
+    </StyledFilterButton>
+  );
+};
+
+const StyledFilterButton = styled(Button)<filterButtonProps>`
+  ${({ toggleClick, theme }) =>
+    toggleClick
+      ? css`
+          color: ${theme.colors.white};
+          background-color: ${theme.colors.orange};
+        `
+      : css`
+          color: ${theme.colors.orange};
+          background-color: transparent;
+        `};
+`;
+
+export default FilterButton;

--- a/src/Components/TodoFilter/FilterButton.tsx
+++ b/src/Components/TodoFilter/FilterButton.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import Button from 'Components/Button';
 
-interface filterButtonProps {
+interface IFilterButtonProps {
   toggleClick: boolean;
   onClick?: () => void;
 }
 
-const FilterButton: React.FC<filterButtonProps> = ({
+const FilterButton: React.FC<IFilterButtonProps> = ({
   toggleClick,
   children,
   ...restProps
@@ -19,7 +19,7 @@ const FilterButton: React.FC<filterButtonProps> = ({
   );
 };
 
-const StyledFilterButton = styled(Button)<filterButtonProps>`
+const StyledFilterButton = styled(Button)<IFilterButtonProps>`
   ${({ toggleClick, theme }) =>
     toggleClick
       ? css`

--- a/src/Components/TodoFilter/TodoFilter.tsx
+++ b/src/Components/TodoFilter/TodoFilter.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { filterItem } from './useTodoFilter';
+import { IFilterItem } from './useTodoFilter';
 import style from 'styled-components';
 import FilterButton from 'Components/TodoFilter/FilterButton';
 
-interface FilterProps {
-  filterList: filterItem[];
-  handleFilter: (filterItem: filterItem) => void;
+interface IFilterProps {
+  filterList: IFilterItem[];
+  handleFilter: (filterItem: IFilterItem) => void;
 }
 
-const TodoFilter: React.FC<FilterProps> = ({ filterList, handleFilter }) => {
+const TodoFilter: React.FC<IFilterProps> = ({ filterList, handleFilter }) => {
   return (
     <TodoFilterWrapper>
       {filterList.map((filterItem) => (

--- a/src/Components/TodoFilter/TodoFilter.tsx
+++ b/src/Components/TodoFilter/TodoFilter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { filterItem } from './useTodoFilter';
+import style from 'styled-components';
+import FilterButton from 'Components/TodoFilter/FilterButton';
+
+interface FilterProps {
+  filterList: filterItem[];
+  handleFilter: (filterItem: filterItem) => void;
+}
+
+const TodoFilter: React.FC<FilterProps> = ({ filterList, handleFilter }) => {
+  return (
+    <TodoFilterWrapper>
+      {filterList.map((filterItem) => (
+        <FilterButton
+          key={filterItem.id}
+          toggleClick={filterItem.toggleClick}
+          onClick={() => handleFilter(filterItem)}
+        >
+          {filterItem.filterName}
+        </FilterButton>
+      ))}
+    </TodoFilterWrapper>
+  );
+};
+
+const TodoFilterWrapper = style.div`
+  width: 100%;
+  display : flex;
+  justify-content : space-between;
+`;
+export default TodoFilter;

--- a/src/Components/TodoFilter/index.ts
+++ b/src/Components/TodoFilter/index.ts
@@ -1,0 +1,3 @@
+import TodoFilter from './TodoFilter';
+
+export default TodoFilter;

--- a/src/Components/TodoFilter/useTodoFilter.ts
+++ b/src/Components/TodoFilter/useTodoFilter.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+export type Itodo = {
+  id: number;
+  taskName: string;
+  stateId: number;
+  createdAt: string;
+  updatedAt: string;
+  dueDate: string;
+};
+
+export interface filterItem {
+  readonly filterName: string;
+  readonly id: number;
+  readonly targetId: number | null;
+  toggleClick: boolean;
+}
+
+interface todoFilterProps {
+  todos: Itodo[];
+  filter: filterItem[];
+}
+
+export const useTodoFilter = ({ todos = [], filter = [] }: todoFilterProps) => {
+  const [filterList, setFilterList] = useState(filter);
+  const [filterTodos, setFilterTodos] = useState(todos);
+
+  const handleFilter = (filterItem: filterItem): void => {
+    const nextFilterList = filterList.map((prefilterItem) =>
+      filterItem.id === prefilterItem.id
+        ? { ...prefilterItem, toggleClick: !prefilterItem.toggleClick }
+        : { ...prefilterItem, toggleClick: false },
+    );
+    setFilterList(nextFilterList);
+
+    if (filterItem.targetId === null) {
+      setFilterTodos(todos);
+    } else {
+      setFilterTodos(
+        todos.filter((todo) => todo.stateId === filterItem.targetId),
+      );
+    }
+  };
+
+  return {
+    filterList,
+    filterTodos,
+    handleFilter,
+  };
+};

--- a/src/Components/TodoFilter/useTodoFilter.ts
+++ b/src/Components/TodoFilter/useTodoFilter.ts
@@ -1,31 +1,34 @@
 import { useState } from 'react';
 
-export type Itodo = {
+export interface Itodo {
   id: number;
   taskName: string;
   stateId: number;
   createdAt: string;
   updatedAt: string;
   dueDate: string;
-};
+}
 
-export interface filterItem {
+export interface IFilterItem {
   readonly filterName: string;
   readonly id: number;
   readonly targetId: number | null;
   toggleClick: boolean;
 }
 
-interface todoFilterProps {
+interface ITodoFilterProps {
   todos: Itodo[];
-  filter: filterItem[];
+  filter: IFilterItem[];
 }
 
-export const useTodoFilter = ({ todos = [], filter = [] }: todoFilterProps) => {
+export const useTodoFilter = ({
+  todos = [],
+  filter = [],
+}: ITodoFilterProps) => {
   const [filterList, setFilterList] = useState(filter);
   const [filterTodos, setFilterTodos] = useState(todos);
 
-  const handleFilter = (filterItem: filterItem): void => {
+  const handleFilter = (filterItem: IFilterItem): void => {
     const nextFilterList = filterList.map((prefilterItem) =>
       filterItem.id === prefilterItem.id
         ? { ...prefilterItem, toggleClick: !prefilterItem.toggleClick }


### PR DESCRIPTION
## PR 제목
투두 아이템 모달에 필요한 필터 및 UI  추가


## 해당 이슈 📎
투두 아이템 모달 - 필터 #3 

## 변경 사항 🛠
- `filterButton` : 클릭시 필터가 고정되게 보일수 있도록 함
- 'useTodoFilter' : 필터 로직, TotoList를 리턴함
- 'TodoFilter' : 전체 필터 버튼을 wrap

## 리뷰어 참고 사항 🙋‍♀️
useTodoFilter를 이용해 재사용할 수 있도록 해보았습니다. 리턴으로 필터링된 todo[]를 받을 수 있습니다.